### PR TITLE
Cache script relative path to avoid constant lookups

### DIFF
--- a/lib/wolverine/script.rb
+++ b/lib/wolverine/script.rb
@@ -65,7 +65,7 @@ class Wolverine
     end
 
     def relative_path
-      path = @file.relative_path_from(@config.script_path)
+      @path ||= @file.relative_path_from(@config.script_path)
     end
 
     def load_lua file


### PR DESCRIPTION
@burke @hornairs @ssoroka Please review

Profiling object creation with this dtrace probe:

```
sudo dtrace -n 'ruby*:::object-create{@[copyinstr(arg0),copyinstr(arg1),arg2]=count();}' -p 66284 
```

Found that in a single request to my local shop's frontpage:

/Users/tom/.rbenv/versions/1.9.3-p194-dtrace/lib/ruby/1.9.1/pathname.rb creates 436 Strings and 436 Pathname objects.

I traced it back to the change in this commit.

After this commit those ~1000 objects do not get instantiated per request.  This was #8 and #9 most allocating lines of code in that request.
