### PR TITLE
Add homepage link to gemspec

### DIFF
--- a/wolverine.gemspec
+++ b/wolverine.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = Wolverine::VERSION
   s.authors     = ["Burke Libbey"]
   s.email       = ["burke@burkelibbey.org"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/Shopify/wolverine"
   s.summary     = %q{Wolverine provides a simple way to run server-side redis scripts from a rails app}
   s.description = %q{Wolverine provides a simple way to run server-side redis scripts from a rails app}
 


### PR DESCRIPTION
Ensures the homepage link will show up on the RubyGems page for wolverine.
