### PR TITLE
Cache methods on Wolverine

### DIFF
--- a/lib/wolverine.rb
+++ b/lib/wolverine.rb
@@ -30,6 +30,7 @@ class Wolverine
   # @return [void]
   def self.reset!
     @root_directory = nil
+    reset_cached_methods
   end
 
   # Used to handle dynamic accesses to scripts. Successful lookups will be
@@ -58,6 +59,7 @@ class Wolverine
 
   def reset!
     @root_directory = nil
+    reset_cached_methods
   end
 
   def method_missing sym, *args
@@ -69,11 +71,31 @@ class Wolverine
   private
 
   def self.root_directory
-    @root_directory ||= PathComponent.new(config.script_path)
+    @root_directory ||= PathComponent.new(config.script_path, {:cache_to => self})
+  end
+
+  def self.cached_methods
+    @cached_methods ||= Hash.new
+  end
+
+  def self.reset_cached_methods
+    metaclass = class << self; self; end
+    cached_methods.each_key { |method| metaclass.send(:undef_method, method) }
+    cached_methods.clear
   end
 
   def root_directory
-    @root_directory ||= PathComponent.new(config.script_path, {:config => config, :redis => redis})
+    @root_directory ||= PathComponent.new(config.script_path, {:cache_to => self, :config => config, :redis => redis})
+  end
+
+  def cached_methods
+    @cached_methods ||= Hash.new
+  end
+
+  def reset_cached_methods
+    metaclass = class << self; self; end
+    cached_methods.each_key { |method| metaclass.send(:undef_method, method) }
+    cached_methods.clear
   end
 
 end

--- a/test/integration/wolverine_integration_test.rb
+++ b/test/integration/wolverine_integration_test.rb
@@ -20,6 +20,7 @@ class WolverineIntegrationTest < MiniTest::Unit::TestCase
     Wolverine.config.script_path = Pathname.new(File.expand_path('../lua', __FILE__))
 
     assert_equal [1, 0], Wolverine.util.mexists(:a, :b)
+    assert Wolverine.methods.include?(:util)
   end
 
   def test_everything_instantiated
@@ -28,6 +29,7 @@ class WolverineIntegrationTest < MiniTest::Unit::TestCase
 
     wolverine = Wolverine.new(config)
     assert_equal [1, 0], wolverine.util.mexists(:a, :b)
+    assert wolverine.methods.include?(:util)
   end
 
 end


### PR DESCRIPTION
This pull request adds a method cache mechanism as suggested in TODO. I would appreciate it if you could kindly review and give any comments.

Currently, the code below always calls Wolverine.method_missing because it does not cache `mexists` as a method.

``` ruby
redis = Redis.new
redis.set(:foo, :foo)
Wolverine.config.redis = redis
Wolverine.config.script_path = Pathname.new(File.join(here, 'examples'))
p Wolverine.methods.include?(:mexists) # => false
p Wolverine.mexists([:foo, :bar, :baz]) # => [1, 0, 0]
p Wolverine.methods.include?(:mexists) # => false
```

After applying this patch, the same code caches `mexists` as a class method.

``` ruby
redis = Redis.new
redis.set(:foo, :foo)
Wolverine.config.redis = redis
Wolverine.config.script_path = Pathname.new(File.join(here, 'examples'))
p Wolverine.methods.include?(:mexists) # => false
p Wolverine.mexists([:foo, :bar, :baz]) # => [1, 0, 0]
p Wolverine.methods.include?(:mexists) # => true
```

And Wolverine.reset! clears cached methods.

``` ruby
Wolverine.methods.include?(:mexists) # => true
Wolverine.reset!
Wolverine.methods.include?(:mexists) # => false
```

The method cache works in case that Wolverine objects are instantiated.
