### PR TITLE
Use original args during fallback to eval

### DIFF
--- a/lib/wolverine/script.rb
+++ b/lib/wolverine/script.rb
@@ -32,10 +32,11 @@ class Wolverine
     #   runtime error
     def call redis, *args
       t = Time.now
+      args_copy = args.dup
       begin
         run_evalsha redis, *args
       rescue => e
-        e.message =~ /NOSCRIPT/ ? run_eval(redis, *args) : raise
+        e.message =~ /NOSCRIPT/ ? run_eval(redis, *args_copy) : raise
       end
     rescue => e
       if LuaError.intercepts?(e)

--- a/lib/wolverine/script.rb
+++ b/lib/wolverine/script.rb
@@ -32,7 +32,13 @@ class Wolverine
     #   runtime error
     def call redis, *args
       t = Time.now
-      args_copy = args.dup
+      args_copy = args.map do |arg| 
+        if arg.is_a?(Hash)
+          arg.dup
+        else
+          arg
+        end
+      end
       begin
         run_evalsha redis, *args
       rescue => e

--- a/test/integration/wolverine_integration_test.rb
+++ b/test/integration/wolverine_integration_test.rb
@@ -32,4 +32,57 @@ class WolverineIntegrationTest < MiniTest::Unit::TestCase
     assert wolverine.methods.include?(:util)
   end
 
+  # This class emulates the behaviour of redis-namespace
+  # https://github.com/resque/redis-namespace/blob/master/lib/redis/namespace.rb#L415-L418
+  class EvilRedis
+    include ::MiniTest::Assertions
+
+    @original_args = nil
+
+    def evalsha(_digest, *args)
+      @original_args = args.map {|x| x.dup}
+      if args.last.is_a?(Hash)
+        args.last[:keys] = modify_key(args.last[:keys])
+      else
+        args[0] = modify_key(args[0])
+      end
+      raise "NOSCRIPT"
+    end
+
+    def eval(_content, *args)
+      assert_equal @original_args, args
+      return [1, 0]
+    end
+
+    private
+
+    def modify_key(key)
+      return key unless key
+
+      case key
+      when Array
+        key.map {|k| modify_key k}
+      when Hash
+        Hash[*key.map {|k, v| [ modify_key(k), v ]}.flatten]
+      else
+        "modified:#{key}"
+      end
+    end
+  end
+
+  def get_test_script
+    redis = EvilRedis.new
+    Wolverine.config.script_path = Pathname.new(File.expand_path('../lua', __FILE__))
+    test_script = Wolverine::Script.new(File.expand_path('../lua/util/mexists.lua', __FILE__))
+  end
+
+  def test_retries_with_original_hash_args
+    result = get_test_script.call(
+      EvilRedis.new,
+      keys: [:a, :b],
+      argv: [:d, :e]
+    )
+    assert_equal [1, 0], result
+  end
+
 end


### PR DESCRIPTION
I've run into an annoying bug when using `wolverine` with `redis-namespace` during https://github.com/Shopify/shopify/pull/86661.

Wolverine has the following optimization:

```
      begin
        run_evalsha redis, *args
      rescue => e
        e.message =~ /NOSCRIPT/ ? run_eval(redis, *args) : raise
      end
```

The problem with this code is that when using `redis-namespace` the `args` hash will be [modified by the callee ](https://github.com/resque/redis-namespace/blob/master/lib/redis/namespace.rb#L415-L418) to prefix an optional namespace (e.g. `resque:my_first_queue`). Therefore on the first try of a new(ly modified) Lua script, the `sha` has changed, the first call will fail, but now the second call will prepend the namespace twice (e.g. `resque:resque:my_first_queue`), causing hard to find logic errors in the Lua code being invoked. 

Once the script is cached this problem no longer occurs, making it repeatable but intermittent.

The fix here is to simply dup the original arguments before retrying.

r: @burke @fw42 
cc: @fbogsany 