### PR TITLE
Make private class methods work

### DIFF
--- a/lib/wolverine.rb
+++ b/lib/wolverine.rb
@@ -87,16 +87,19 @@ class Wolverine
   def self.root_directory
     @root_directory ||= PathComponent.new(config.script_path, {:cache_to => self})
   end
+  private_class_method :root_directory
 
   def self.cached_methods
     @cached_methods ||= Hash.new
   end
+  private_class_method :cached_methods
 
   def self.reset_cached_methods
     metaclass = class << self; self; end
     cached_methods.each_key { |method| metaclass.send(:undef_method, method) }
     cached_methods.clear
   end
+  private_class_method :reset_cached_methods
 
   def root_directory
     @root_directory ||= PathComponent.new(config.script_path, {:cache_to => self, :config => config, :redis => redis})
@@ -111,5 +114,4 @@ class Wolverine
     cached_methods.each_key { |method| metaclass.send(:undef_method, method) }
     cached_methods.clear
   end
-
 end


### PR DESCRIPTION
After reading the current codes and histories, I thought that some class methods of Wolverine were designed to be private but actually are not private.

By using `private_class_method`, these class methods can be changed to private methods.
Although `private_class_method` can handle multiple class methods by one call, IMHO this seemingly redundant way could improve readability.

Also, I have removed the extra empty line at the end of the code.

If my assumption is right and our policy admits slight backward-incompatibility, I would like to apply this patch.