### PR TITLE
Fix deprecation and warnings

### DIFF
--- a/lib/wolverine.rb
+++ b/lib/wolverine.rb
@@ -24,7 +24,7 @@ class Wolverine
   end
 
   def self.statsd_enabled?
-    @statsd_enabled
+    defined?(@statsd_enabled) && @statsd_enabled
   end
 
   def self.enable_statsd!

--- a/lib/wolverine/lua_error.rb
+++ b/lib/wolverine/lua_error.rb
@@ -26,7 +26,7 @@ class Wolverine
       @file = file
 
       @error.message =~ PATTERN
-      stage, line_number, message = $1, $2, $3
+      _stage, line_number, message = $1, $2, $3
 
       super message
       set_backtrace generate_backtrace file, line_number

--- a/lib/wolverine/path_component.rb
+++ b/lib/wolverine/path_component.rb
@@ -50,7 +50,7 @@ class Wolverine
     end
 
     def file?(path)
-      File.exists?(path) && !File.directory?(path)
+      File.exist?(path) && !File.directory?(path)
     end
 
     def define_directory_method path, sym
@@ -64,7 +64,7 @@ class Wolverine
     def define_script_method path, sym, *args
       redis, options = @redis, @options.merge({:cache_to => nil})
       script = Wolverine::Script.new(path, options)
-      cb = proc { |*args| script.call(redis, *args) }
+      cb = proc { |*cb_args| script.call(redis, *cb_args) }
       define_metaclass_method(sym, &cb) 
       cache_metaclass_method(sym, &cb)
     end

--- a/test/wolverine/script_test.rb
+++ b/test/wolverine/script_test.rb
@@ -28,7 +28,7 @@ class Wolverine
       rescue Wolverine::LuaError => e
         assert_equal "attempt to compare nil with number", e.message
         assert_equal "/a/b/c/d/e/file1.lua:1", e.backtrace.first
-        assert_match /script.rb/, e.backtrace[1]
+        assert_match(/script.rb/, e.backtrace[1])
       end
     end
 


### PR DESCRIPTION
I have fixed 1 deprecation and 4 warnings.

### Deprecation

* `lib/wolverine/path_component.rb:53: warning: File.exists? is a deprecated name, use File.exist? instead`
    * `exists?` was deprecated on Ruby 2.1.0 http://ruby-doc.org/core-2.1.0/File.html#method-c-exists-3F

### Warnings

* `lib/wolverine/path_component.rb:67: warning: shadowing outer local variable - args`
* `lib/wolverine/lua_error.rb:29: warning: assigned but unused variable - stage`
* `test/wolverine/script_test.rb:31: warning: ambiguous first argument; put parentheses or a space even after `/' operator`
* `lib/wolverine.rb:27: warning: instance variable @statsd_enabled not initialized`