### PR TITLE
Add valid travis config with build status on README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
-  - jruby-18mode
+  - 2.0.0
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
-
+  - jruby-9.1.9.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wolverine [![Dependency Status](https://gemnasium.com/Shopify/wolverine.png)](https://gemnasium.com/Shopify/wolverine)
+# Wolverine [![Dependency Status](https://gemnasium.com/Shopify/wolverine.png)](https://gemnasium.com/Shopify/wolverine) [![Build Status](https://travis-ci.org/Shopify/wolverine.svg?branch=master)](https://travis-ci.org/Shopify/wolverine)
 
 Wolverine is a simple library to allow you to manage and run redis server-side lua scripts from a rails app, or other ruby code.
 


### PR DESCRIPTION
As test does not pass with current .travis.yml, I have fixed the config so that at least current tests pass.

I edited the config as follows.

* Remove versions older than 1.9.3, since `rake` requires 1.9.3
* Add new ruby versions after or equal to 2.0.0.
* Add latest jruby.
    * `jruby-head` has problem with installing `bundler`, so I did not add it.
* Remove rbx since it is not available in rvm Precise dist.
    * The written version is no longer supported.
    * Running on Rubinius requires us to use Trusty (beta version) instead of Precise.
    * https://docs.travis-ci.com/user/languages/ruby/#Supported-Ruby-Versions-and-RVM

P.S.
Is it possible to enable Travis on this open source repository?
As we can see build result on Pull Requests, this could prevent unintentional test failures.