### PR TITLE
Add Lua script context for more understandable exception

### DIFF
--- a/lib/wolverine/script.rb
+++ b/lib/wolverine/script.rb
@@ -39,7 +39,7 @@ class Wolverine
       end
     rescue => e
       if LuaError.intercepts?(e)
-        raise LuaError.new(e, @file)
+        raise LuaError.new(e, @file, @content)
       else
         raise
       end


### PR DESCRIPTION
Hi. 🐱 

I would like to add Lua context to exception message so that we can trace the exact cause easily and fastly.

## Exception Message Change

Before:
```
Wolverine::LuaError: attempt to compare nil with number
from /a/b/c/d/e/file1.lua:5
```

After:
```
Wolverine::LuaError: attempt to compare nil with number

    3:
    4: local rank = redis.call('ZRANK', key, member)
 => 5: if rank > max_rank then
    6:   return {}
    7: end

from /a/b/c/d/e/file1.lua:5
```

## Background

One of the advantages of using Wolverine for Lua on Redis is the sophisticated script management. We can write concise and flexible scripts by the power of ERB.

However, since Wolverine sends the processed text to Redis, line numbers in exceptions do not always reflect the original line number, which deteriorate debugging efficiency. We sometimes look into directly-called script, and then go back and forth tracing `include_partial` or other functions until we finally meet the corresponding line number.

By showing the context of processed Lua script in exception, in most cases, we can skip the above processes. Some causes can be found by heart, other causes can be found by grep. (IMHO, grep over root_directory is effective enough to most of Lua scripts using only `include_partial`)